### PR TITLE
Removed OnlyDirectAlerts key from web.config

### DIFF
--- a/NLTD.EmployeePortal.LMS.Dac/Dac/EmployeeDac.cs
+++ b/NLTD.EmployeePortal.LMS.Dac/Dac/EmployeeDac.cs
@@ -912,6 +912,7 @@ namespace NLTD.EmployeePortal.LMS.Dac.Dac
                             employee.DOJ = profile.DOJ;
                             employee.ConfirmationDate = profile.ConfirmationDate;
                             employee.RelievingDate = profile.RelievingDate;
+                            employee.OnlyDirectAlerts = false;//When new employee added, setting this default flag
                             employee.ModifiedBy = -1;
                             employee.CreatedBy = ModifiedBy;
                             employee.CreatedOn = System.DateTime.Now;

--- a/NLTD.EmployeePortal.LMS.Dac/Dac/LeaveDac.cs
+++ b/NLTD.EmployeePortal.LMS.Dac/Dac/LeaveDac.cs
@@ -2843,16 +2843,15 @@ namespace NLTD.EmployeePortal.LMS.Dac
             try
             {
                 if (lstCCEmail.Count > 0 && reportingToUserId != null)
-                {
-                    string onlyDirectAlerts = ConfigurationManager.AppSettings["OnlyDirectAlerts"].ToString();
-                    List<string> lstOptoutEmailAddress = onlyDirectAlerts.Split(',').ToList();
+                {                    
+                    List<string> lstOptoutEmailAddress = GetOnlyDirectAlertsEmailIds();
                     using (var context = new NLTDDbContext())
                     {
                         var qryReportingTo = context.Employee.Where(x => x.UserId == reportingToUserId).FirstOrDefault();
 
                         foreach (var item in lstOptoutEmailAddress)
                         {
-                            if (qryReportingTo.EmailAddress.ToUpper() != item.ToUpper())
+                            if (qryReportingTo.EmailAddress.ToUpper() != item.ToUpper())//If employee is not directly reporting to person in OptOut list, remove email from cc list.
                             {
                                 lstCCEmail.Remove(item);
                             }
@@ -2863,6 +2862,19 @@ namespace NLTD.EmployeePortal.LMS.Dac
             catch { throw; }
 
             return lstCCEmail;
+        }
+        private List<string> GetOnlyDirectAlertsEmailIds()
+        {
+            List<string> onlyDirectAlertsEmailIdsList = new List<string>();
+            try
+            {
+                using (var context = new NLTDDbContext())
+                {
+                    onlyDirectAlertsEmailIdsList = context.Employee.Where(x => x.OnlyDirectAlerts == true).Select(x=>x.EmailAddress).ToList();                    
+                }
+            }
+            catch { throw; }
+            return onlyDirectAlertsEmailIdsList;
         }
 
         public EmailDataModel GetEmailData(Int64 leaveId, string actionName)

--- a/NLTD.EmployeePortal.LMS.Dac/DbModel/Employee.cs
+++ b/NLTD.EmployeePortal.LMS.Dac/DbModel/Employee.cs
@@ -40,5 +40,7 @@ namespace NLTD.EmployeePortal.LMS.Dac.DbModel
         public Boolean? SkipTimesheetCompliance { get; set; }
 
         public Int64 EmploymentTypeId { get; set; }
+
+        public bool OnlyDirectAlerts { get; set; }
     }
 }

--- a/NLTD.EmployeePortal.LMS.Ux/Web.config
+++ b/NLTD.EmployeePortal.LMS.Ux/Web.config
@@ -47,8 +47,6 @@
     <add key="MinimumDailyTime" value="08:00" />
     <!--Format hh:mm sample 09:00-->
     <add key="MinimumWeekTime" value="45:00" />
-    <!--Email Addresses of users who want to receive email alert only from the employees reporting directly separated by comma-->
-    <add key="OnlyDirectAlerts" value="sviswanathan@nltechdev.com" />
     <add key="NumberOfLeaveExceptionsAllowed" value="1" />
     <add key="HeartbeatUrl" value="http://localhost:55457/Home/Heartbeat" />
   </appSettings>


### PR DESCRIPTION
Removed OnlyDirectAlerts key from web.config and added same column in Employee table.

DB script:

ALTER TABLE Employee ADD OnlyDirectAlerts bit  NULL
UPDATE Employee SET OnlyDirectAlerts=0
ALTER TABLE Employee ALTER COLUMN OnlyDirectAlerts bit  NOT NULL